### PR TITLE
Add --apple-use-keychain option to ssh-add

### DIFF
--- a/lib/git_swap/swapper.rb
+++ b/lib/git_swap/swapper.rb
@@ -80,10 +80,11 @@ module GitSwap
 
     def set_ssh
       `git config #{git_config_flag} core.sshCommand "#{ssh_command}"`
+      # Include the --apple-use-keychain option to retrieve the passphrase
       if options.verbose?
-        `ssh-add #{ssh}`
+        `ssh-add --apple-use-keychain #{ssh}`
       else
-        `ssh-add #{ssh} 2>/dev/null`
+        `ssh-add --apple-use-keychain #{ssh} 2>/dev/null`
       end
     end
 


### PR DESCRIPTION
Trying to avoid re-entering the passphrase every time you switch profiles.