### PR TITLE
Remove activesupport

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           command: bundle -v
       - run:
           name: Install bundler
-          command: gem install bundler -v 2.2.10
+          command: gem install bundler -v 2.3.7
       - ruby/install-deps
 
   test:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,50 +2,37 @@ PATH
   remote: .
   specs:
     git_swap (1.1.3)
-      activesupport (~> 5.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.6)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-    concurrent-ruby (1.1.9)
-    diff-lcs (1.3)
-    i18n (1.9.1)
-      concurrent-ruby (~> 1.0)
-    minitest (5.15.0)
-    rake (13.0.1)
-    rspec (3.8.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.0)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    diff-lcs (1.5.0)
+    rake (13.0.6)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    thread_safe (0.3.6)
-    tzinfo (1.2.9)
-      thread_safe (~> 0.1)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-20
 
 DEPENDENCIES
-  bundler (~> 2.2.10)
+  bundler (~> 2.3.7)
   git_swap!
   rake (>= 12.3.3)
   rspec (~> 3.0)
   rspec_junit_formatter (~> 0.4.1)
 
 BUNDLED WITH
-   2.2.10
+   2.3.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   bundler (~> 2.3.7)

--- a/git_swap.gemspec
+++ b/git_swap.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables   << 'git-swap'
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.2.10"
+  spec.add_development_dependency "bundler", "~> 2.3.7"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.4.1"

--- a/git_swap.gemspec
+++ b/git_swap.gemspec
@@ -28,8 +28,6 @@ Gem::Specification.new do |spec|
   spec.executables   << 'git-swap'
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", "~> 5.2"
-
   spec.add_development_dependency "bundler", "~> 2.2.10"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/git_swap/swapper.rb
+++ b/lib/git_swap/swapper.rb
@@ -1,11 +1,8 @@
 require_relative './version'
-require 'active_support/core_ext/module/delegation'
 
 module GitSwap
   class Swapper
     attr_reader :config, :options
-    delegate :usage?, :config?, :edit?, :list?, :version?, :global?, to: :options
-    delegate :profile, :name, :username, :email, :ssh, :ssh_command, :print_list, :configure!, :edit!, :valid_profile?, to: :config
 
     def initialize(args)
       raise ArgumentError unless args.is_a? Array
@@ -63,6 +60,20 @@ module GitSwap
         puts `ssh-add -l`
       else
         puts "Swapped to profile #{profile}"
+      end
+    end
+
+    # Use method_missing for delegation
+    # Original ActiveSupport version
+    # delegate :usage?, :config?, :edit?, :list?, :version?, :global?, to: :options
+    # delegate :profile, :name, :username, :email, :ssh, :ssh_command, :print_list, :configure!, :edit!, :valid_profile?, to: :config
+    def method_missing(method, *args)
+      if @options.respond_to?(method)
+        @options.send(method, *args)
+      elsif @config.respond_to?(method)
+        @config.send(method, *args)
+      else
+        super
       end
     end
 


### PR DESCRIPTION
Remove activesupport gem to simplify Homebrew install. I was only using ActiveSupport for delegation, and can use `method_missing` instead.