### PR TITLE
Handle missing config file

### DIFF
--- a/lib/git_swap/config.rb
+++ b/lib/git_swap/config.rb
@@ -121,7 +121,8 @@ module GitSwap
     private
 
     def load!
-      # TODO: RCR - Handle missing or empty config file
+      # If configuration file hasn't been created yet, load an empty hash
+      return {} unless File.file?(File.expand_path('~/.gitswap'))
       YAML.load_file(File.expand_path('~/.gitswap')) || {}
     end
 

--- a/spec/lib/git_swap/config_spec.rb
+++ b/spec/lib/git_swap/config_spec.rb
@@ -1,6 +1,19 @@
 require 'spec_helper'
 
 RSpec.describe GitSwap::Config do
+  describe 'initialize' do
+    context 'when .gitswap file does not exist' do
+      before :each do
+        allow(File).to receive(:expand_path).with('~/.gitswap').and_return(File.expand_path('spec/fixtures/.nofile'))
+      end
+      let(:config) { GitSwap::Config.new(['personal']) }
+
+      it 'does not error' do
+        expect(config.profiles).to eq Hash.new
+      end
+    end
+  end
+
   describe 'profile attributes' do
     let(:config) { GitSwap::Config.new(['personal']) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
+    # Use fixture file by default
     allow(File).to receive(:expand_path).and_call_original
     allow(File).to receive(:expand_path).with('~/.gitswap').and_return(File.expand_path('spec/fixtures/.gitswap'))
   end


### PR DESCRIPTION
* Handle case where git swap is being run for the first time, with no arguments, and .gitswap file does not yet exist