### PR TITLE
Bump version to 1.1.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git_swap (1.1.4)
+    git_swap (1.1.5)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/git_swap/version.rb
+++ b/lib/git_swap/version.rb
@@ -1,3 +1,3 @@
 module GitSwap
-  VERSION = "1.1.4" unless defined? VERSION
+  VERSION = "1.1.5" unless defined? VERSION
 end


### PR DESCRIPTION
* Handle case where git swap is being run for the first time, with no arguments, and .gitswap file does not yet exist